### PR TITLE
Console view css update

### DIFF
--- a/src/app/plugins/console/console.component.scss
+++ b/src/app/plugins/console/console.component.scss
@@ -1,0 +1,10 @@
+.xterm-viewport {
+	width: auto !important;
+}
+
+.xterm-screen {
+	width: auto !important;
+	> canvas {
+		width: 100% !important;
+	}
+}

--- a/src/app/plugins/console/console.component.ts
+++ b/src/app/plugins/console/console.component.ts
@@ -1,11 +1,13 @@
-import { AfterViewInit, Component, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, ViewChild, ViewEncapsulation } from '@angular/core';
 import { NgTerminal } from 'ng-terminal';
 import { AppService } from '../../app.service';
 
 @Component({
 	selector: 'lthn-app-console',
 	templateUrl: './console.component.html',
-	styleUrls: ['./console.component.scss']
+	styleUrls: ['./console.component.scss'],
+	encapsulation: ViewEncapsulation.None
+
 })
 export class ConsoleComponent implements AfterViewInit {
 	@ViewChild('term', { static: true }) child: NgTerminal;


### PR DESCRIPTION
# Description
Change way how width of console window is calculated. Tmux.js lib calculates xterm DOM element width using JS, but because ```onResizeEnd``` method is not called during css animation, it made elements flow out of border and resize in step-like manner on sidenav open/close. This fix scales console element fluently, but the step-like behaviour is translated to aspect ratio of tmux canvas. In my opinion it looks a lot better.

Also for some reason tmux-viewport div width didn't get resized at all, it is also fixed here.