### PR TITLE
Fix sidenav close icon

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -6,7 +6,7 @@
                 <img alt="Lethean Logo" class="logo" src="../assets/images/logo.png"/>
             </a>
             <button (click)="closeMenu()" *ngIf="menu" mat-button>
-                <mat-icon>menu_close</mat-icon>
+                <mat-icon>menu</mat-icon>
             </button>
         </div>
 


### PR DESCRIPTION
# Description
As there is no menu_close icon, menu and close icons get concatinated. 
It can be seen by scrolling sidenav to side.
![Screenshot from 2021-11-27 11-03-12](https://user-images.githubusercontent.com/32670609/143675877-52fdf0c4-33a3-4f8a-868b-73bddb3bf36c.png)

So just use menu icon for now.